### PR TITLE
finslib_udp_connect: set timeout option for udp socket

### DIFF
--- a/src/fins_io.c
+++ b/src/fins_io.c
@@ -338,6 +338,7 @@ struct fins_sys_tp *finslib_tcp_connect( struct fins_sys_tp *sys, const char *ad
 struct fins_sys_tp *finslib_udp_connect( struct fins_sys_tp *sys, const char *address, uint16_t port, uint8_t local_net, uint8_t local_node, uint8_t local_unit, uint8_t remote_net, uint8_t remote_node, uint8_t remote_unit, int *error_val, int error_max ) {
 
 	struct sockaddr_in ws_addr;
+	struct timeval tv;
 
 	if ( sys != NULL  &&  finslib_monotonic_sec_timer() < sys->timeout + FINS_TIMEOUT  &&  sys->timeout > 0 ) {
 
@@ -379,6 +380,16 @@ struct fins_sys_tp *finslib_udp_connect( struct fins_sys_tp *sys, const char *ad
 	}
 
 	sys->sockfd = socket( AF_INET, SOCK_DGRAM, IPPROTO_UDP );
+
+	tv.tv_sec  = SEND_TIMEOUT;
+	tv.tv_usec = 0;
+
+	if ( setsockopt( sys->sockfd, SOL_SOCKET, SO_SNDTIMEO, (setsockopt_tp *) & tv, sizeof(tv) ) < 0 ) return fins_close_socket_with_error( sys, error_val );
+
+	tv.tv_sec  = RECV_TIMEOUT;
+	tv.tv_usec = 0;
+
+	if ( setsockopt( sys->sockfd, SOL_SOCKET, SO_RCVTIMEO, (setsockopt_tp *) & tv, sizeof(tv) ) < 0 ) return fins_close_socket_with_error( sys, error_val );
 
 	if ( sys->sockfd == INVALID_SOCKET ) return fins_close_socket_with_error( sys, error_val );
 


### PR DESCRIPTION
Default socket values SO_RCVTIMEO & SO_RCVTIMEO are zero. (https://linux.die.net/man/3/setsockopt) As long as PLC is not reachable, communication hangs.